### PR TITLE
Switched test_cli to use to sys.executable

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 import platform
 import subprocess
+import sys
 
 import pytest
 from PIL import Image
@@ -100,6 +101,6 @@ def test_cli_version(capsys):
 def test_main_access_cli(flag, return_code, image_with_metadata):
     """Confirm that CLI can be accessed via python -m."""
     result = subprocess.run(
-        ['python', '-m', 'exif_stripper.cli', flag or str(image_with_metadata)]
+        [sys.executable, '-m', 'exif_stripper.cli', flag or str(image_with_metadata)]
     )
     assert result.returncode == return_code


### PR DESCRIPTION
Some tests fail on my machine but they are related to xargs:

```
============================================================================= short test summary info =============================================================================
ERROR tests/test_cli.py::test_process_image_full - OSError: [Errno 95] Operation not supported: b'/tmp/pytest-of-felipe/pytest-30/test_process_image_full0/test.png'
ERROR tests/test_cli.py::test_main_access_cli[--version-0] - OSError: [Errno 95] Operation not supported: b'/tmp/pytest-of-felipe/pytest-30/test_main_access_cli___version0/test.png'
ERROR tests/test_cli.py::test_main_access_cli[-1] - OSError: [Errno 95] Operation not supported: b'/tmp/pytest-of-felipe/pytest-30/test_main_access_cli__1_0/test.png'
ERROR tests/test_cli.py::test_main - OSError: [Errno 95] Operation not supported: b'/tmp/pytest-of-felipe/pytest-30/test_main0/test.png'
=========================================================================== 4 passed, 4 errors in 0.16s ===========================================================================
```

For reference, architecture info
```
Linux 6.8.0-76060800daily20240311-generic #202403110203~1714077665~22.04~4c8e9a0~dev-Ubuntu SMP PREEMPT_DY x86_64 x86_64 x86_64 GNU/Linux
```