### PR TITLE
fix: check whether xattr is changed before and after clear

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,9 +86,9 @@ def test_process_image_full(image_with_metadata, monkeypatch, recwarn):
     # Unremovable attributes may not be present in all system setups.
     # This is to assert the warning message if the user has such system configurations.
     if recwarn:
-        message = str(recwarn[0].message)
-        assert message.startswith('Extended attributes')
-        assert message.endswith('cannot be removed.')
+        message = str(recwarn[0].message)  # pragma: no cover
+        assert message.startswith('Extended attributes')  # pragma: no cover
+        assert message.endswith('cannot be removed.')  # pragma: no cover
 
 
 def test_process_image_exif_only(image_with_exif_data, monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -78,15 +78,24 @@ def assert_metadata_stripped(filepath, on_windows=RUNNING_ON_WINDOWS):
 
 
 @pytest.mark.skipif(RUNNING_ON_WINDOWS, reason='xattr does not work on Windows')
-def test_process_image_full(image_with_metadata, monkeypatch):
+def test_process_image_full(image_with_metadata, monkeypatch, recwarn):
     """Test that cli.process_image() removes EXIF and extended attributes."""
+
     assert_metadata_stripped(image_with_metadata)
+
+    # Unremovable attributes may not be present in all system setups.
+    # This is to assert the warning message if the user has such system configurations.
+    if recwarn:
+        message = str(recwarn[0].message)
+        assert message.startswith('Extended attributes')
+        assert message.endswith('cannot be removed.')
 
 
 def test_process_image_exif_only(image_with_exif_data, monkeypatch):
     """Test that cli.process_image() removes EXIF only (Windows version)."""
     if not RUNNING_ON_WINDOWS:
         monkeypatch.setattr(platform, 'system', lambda: 'Windows')
+
     assert_metadata_stripped(image_with_exif_data, on_windows=True)
 
 


### PR DESCRIPTION
<!-- Which issue does this address? -->
Fixes https://github.com/stefmolin/exif-stripper/issues/56

**Describe your changes**

<!-- TODO -->

*Why*
Some extend attributes cannot be removed in certain setups on macOS, which would cause
the file being modified meaninglessly

**Checklist**

<!-- Place an X between the [ ] for completed tasks -->

- [x] Test cases have been modified/added to cover any code changes.
- [x] Docstrings have been modified/created for any code changes.
- [x] All linting and formatting checks pass (see the [contributing guidelines](https://github.com/stefmolin/exif-stripper/blob/main/CONTRIBUTING.md) for more information).
