### PR TITLE
Always keep ICC profile and orientation to avoid display issues; keep copyright and artist fields by default

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,5 +1,5 @@
 changelog:
   exclude:
     authors:
-      - dependabot
-      - pre-commit.ci
+      - dependabot[bot]
+      - pre-commit-ci[bot]

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,4 +2,4 @@ changelog:
   exclude:
     authors:
       - dependabot
-      - pre-commit-ci
+      - pre-commit.ci

--- a/src/exif_stripper/cli.py
+++ b/src/exif_stripper/cli.py
@@ -43,8 +43,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     exif_options_group.add_argument(
         '--fields',
         nargs='+',
-        choices=list(FieldGroup),
-        default=FieldGroup.ALL,
+        choices=[group for group in FieldGroup if group != FieldGroup.COPYRIGHT],
+        default=(FieldGroup.ALL,),
         help=(
             'The fields to remove from the EXIF metadata. By default, all EXIF metadata '
             'that can safely be deleted is removed.'
@@ -52,8 +52,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     exif_options_group.add_argument(
         '--remove-copyright',
-        action='store_false',
-        dest='preserve_copyright',
+        action='store_true',
         help=(
             'Whether to remove the image copyright information. '
             'By default, the artist and copyright tags will be preserved, if present.'
@@ -62,10 +61,11 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     args = parser.parse_args(argv)
 
-    results = [
-        process_image(filename, args.fields, args.preserve_copyright)
-        for filename in args.filenames
-    ]
+    fields = args.fields
+    if args.remove_copyright:
+        fields = [*fields, FieldGroup.COPYRIGHT]
+
+    results = [process_image(filename, fields=fields) for filename in args.filenames]
     return int(any(results))
 
 

--- a/src/exif_stripper/cli.py
+++ b/src/exif_stripper/cli.py
@@ -46,14 +46,26 @@ def main(argv: Sequence[str] | None = None) -> int:
         choices=list(FieldGroup),
         default=FieldGroup.ALL,
         help=(
-            'The fields to remove from the EXIF metadata. '
-            'By default, all EXIF metadata is removed.'
+            'The fields to remove from the EXIF metadata. By default, all EXIF metadata '
+            'that can safely be deleted is removed.'
+        ),
+    )
+    exif_options_group.add_argument(
+        '--remove-copyright',
+        action='store_false',
+        dest='preserve_copyright',
+        help=(
+            'Whether to remove the image copyright information. '
+            'By default, the artist and copyright tags will be preserved, if present.'
         ),
     )
 
     args = parser.parse_args(argv)
 
-    results = [process_image(filename, args.fields) for filename in args.filenames]
+    results = [
+        process_image(filename, args.fields, args.preserve_copyright)
+        for filename in args.filenames
+    ]
     return int(any(results))
 
 

--- a/src/exif_stripper/fields.py
+++ b/src/exif_stripper/fields.py
@@ -27,7 +27,7 @@ class FieldGroup(StrEnum):
 # References for EXIF tags:
 # - meanings: https://exiv2.org/tags.html
 # - enums: https://pillow.readthedocs.io/en/stable/_modules/PIL/ExifTags.html
-FIELDS: dict[FieldGroup, tuple[IntEnum]] = {
+EXIF_TAG_MAPPING: dict[FieldGroup, tuple[IntEnum]] = {
     FieldGroup.CAMERA: (
         ExifTags.Base.Make,
         ExifTags.Base.Model,
@@ -43,3 +43,16 @@ FIELDS: dict[FieldGroup, tuple[IntEnum]] = {
     ),
 }
 """Mapping of FieldGroup to the corresponding locations in the EXIF metadata."""
+
+
+PRESERVE_FIELDS: tuple[IntEnum] = (
+    ExifTags.Base.InterColorProfile,
+    ExifTags.Base.Orientation,
+)
+"""Locations of EXIF information that should be preserved."""
+
+OWNERSHIP_FIELDS: tuple[IntEnum] = (
+    ExifTags.Base.Artist,
+    ExifTags.Base.Copyright,
+)
+"""Locations of EXIF information related to copyright/ownership."""

--- a/src/exif_stripper/fields.py
+++ b/src/exif_stripper/fields.py
@@ -4,6 +4,18 @@ from enum import IntEnum, StrEnum, auto
 
 from PIL import ExifTags
 
+PRESERVE_FIELDS: tuple[IntEnum] = (
+    ExifTags.Base.InterColorProfile,
+    ExifTags.Base.Orientation,
+)
+"""Locations of EXIF information that should be preserved."""
+
+OWNERSHIP_FIELDS: tuple[IntEnum] = (
+    ExifTags.Base.Artist,
+    ExifTags.Base.Copyright,
+)
+"""Locations of EXIF information related to copyright/ownership."""
+
 
 class FieldGroup(StrEnum):
     """Enum for groups of fields to target."""
@@ -13,6 +25,9 @@ class FieldGroup(StrEnum):
 
     CAMERA = auto()
     """Field group for EXIF tags containing the make and model of the camera."""
+
+    COPYRIGHT = auto()
+    """Field group for EXIF tags related to the creator of the image."""
 
     GPS = auto()
     """Field group for all GPS information in EXIF metadata."""
@@ -34,6 +49,7 @@ EXIF_TAG_MAPPING: dict[FieldGroup, tuple[IntEnum]] = {
         ExifTags.Base.MakerNote,
         ExifTags.Base.MakerNoteSafety,
     ),
+    FieldGroup.COPYRIGHT: OWNERSHIP_FIELDS,
     FieldGroup.GPS: (ExifTags.IFD.GPSInfo,),
     FieldGroup.LENS: (ExifTags.Base.LensMake, ExifTags.Base.LensModel),
     FieldGroup.SERIALS: (
@@ -43,16 +59,3 @@ EXIF_TAG_MAPPING: dict[FieldGroup, tuple[IntEnum]] = {
     ),
 }
 """Mapping of FieldGroup to the corresponding locations in the EXIF metadata."""
-
-
-PRESERVE_FIELDS: tuple[IntEnum] = (
-    ExifTags.Base.InterColorProfile,
-    ExifTags.Base.Orientation,
-)
-"""Locations of EXIF information that should be preserved."""
-
-OWNERSHIP_FIELDS: tuple[IntEnum] = (
-    ExifTags.Base.Artist,
-    ExifTags.Base.Copyright,
-)
-"""Locations of EXIF information related to copyright/ownership."""

--- a/src/exif_stripper/processing.py
+++ b/src/exif_stripper/processing.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+import itertools
 from contextlib import suppress
+from copy import deepcopy
 from typing import TYPE_CHECKING
 
 from PIL import Image, UnidentifiedImageError
 
 from .exceptions import UnknownFieldError
-from .fields import FIELDS, FieldGroup
+from .fields import EXIF_TAG_MAPPING, OWNERSHIP_FIELDS, PRESERVE_FIELDS, FieldGroup
 
 if TYPE_CHECKING:
     import os
@@ -18,6 +20,7 @@ if TYPE_CHECKING:
 def process_image(
     filename: str | os.PathLike,
     fields: Sequence[FieldGroup] = (FieldGroup.ALL,),
+    preserve_copyright: bool = True,
 ) -> bool:
     """
     Process image EXIF metadata.
@@ -28,6 +31,8 @@ def process_image(
         The image file to check.
     fields : Sequence[FieldGroup], default ``(FieldGroup.ALL,)``
        The group of fields to check for and remove, if present.
+    preserve_copyright : bool, default ``True``
+        Whether to preserve the copyright metadata, if present.
 
     Returns
     -------
@@ -40,22 +45,37 @@ def process_image(
         suppress(FileNotFoundError, UnidentifiedImageError),
         Image.open(filename) as image,
     ):
-        if exif := image.getexif():
-            if FieldGroup.ALL in fields:
-                exif.clear()
-                has_changed = True
-            else:
-                for field in fields:
-                    if locations := FIELDS.get(field):
-                        for location in locations:
-                            with suppress(KeyError):
-                                del exif[location]
-                                has_changed = True
-                    else:
-                        raise UnknownFieldError(field, FieldGroup)
+        exif = image.getexif()
 
-            if has_changed:
-                image.save(filename, exif=exif)
-                print(f'Stripped EXIF metadata from {filename}')
+        if FieldGroup.ALL in fields:
+            original_exif = deepcopy(exif)
+
+            fields_to_preserve = {
+                location: value
+                for location in itertools.chain(
+                    PRESERVE_FIELDS, OWNERSHIP_FIELDS if preserve_copyright else {}
+                )
+                if (value := exif.get(location))
+            }
+
+            exif.clear()
+
+            for field, value in fields_to_preserve.items():
+                exif[field] = value
+
+            has_changed = original_exif != exif
+        else:
+            for field in fields:
+                if locations := EXIF_TAG_MAPPING.get(field):
+                    for location in locations:
+                        with suppress(KeyError):
+                            del exif[location]
+                            has_changed = True
+                else:
+                    raise UnknownFieldError(field, FieldGroup)
+
+        if has_changed:
+            image.save(filename, exif=exif)
+            print(f'Stripped EXIF metadata from {filename}')
 
     return has_changed

--- a/src/exif_stripper/processing.py
+++ b/src/exif_stripper/processing.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
 def process_image(
     filename: str | os.PathLike,
     fields: Sequence[FieldGroup] = (FieldGroup.ALL,),
-    preserve_copyright: bool = True,
 ) -> bool:
     """
     Process image EXIF metadata.
@@ -31,8 +30,6 @@ def process_image(
         The image file to check.
     fields : Sequence[FieldGroup], default ``(FieldGroup.ALL,)``
        The group of fields to check for and remove, if present.
-    preserve_copyright : bool, default ``True``
-        Whether to preserve the copyright metadata, if present.
 
     Returns
     -------
@@ -53,7 +50,8 @@ def process_image(
             fields_to_preserve = {
                 location: value
                 for location in itertools.chain(
-                    PRESERVE_FIELDS, OWNERSHIP_FIELDS if preserve_copyright else {}
+                    PRESERVE_FIELDS,
+                    OWNERSHIP_FIELDS if FieldGroup.COPYRIGHT not in fields else {},
                 )
                 if (value := exif.get(location))
             }

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for exif_stripper."""

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,32 @@
+"""Utility functions for testing."""
+
+from PIL import Image
+
+from exif_stripper.fields import (
+    EXIF_TAG_MAPPING,
+    OWNERSHIP_FIELDS,
+    PRESERVE_FIELDS,
+    FieldGroup,
+)
+
+
+def has_expected_metadata(filepath, fields, has_copyright, was_stripped) -> bool:
+    """Utility to check if a file has the expected metadata."""
+    with Image.open(filepath) as im:
+        exif = im.getexif()
+
+        preserved_fields_are_present = all(
+            tag in exif for tag in PRESERVE_FIELDS
+        ) and has_copyright == all(tag in exif for tag in OWNERSHIP_FIELDS)
+
+        if fields is None or FieldGroup.ALL in fields:
+            other_fields_present = all(
+                tag in exif
+                for field in set(FieldGroup).difference({FieldGroup.ALL})
+                for tag in EXIF_TAG_MAPPING[field]
+            )
+            return preserved_fields_are_present and was_stripped != other_fields_present
+
+        return preserved_fields_are_present and was_stripped != all(
+            tag in exif for field in fields for tag in EXIF_TAG_MAPPING[field]
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,60 @@
+"""Common test fixtures."""
+
+import pytest
+from PIL import ExifTags, Image
+
+
+@pytest.fixture
+def image_without_exif_data(tmp_path):
+    """Fixture for an image without EXIF data."""
+    image_without_exif_data = tmp_path / 'clean.png'
+    image_without_exif_data.touch()
+    return image_without_exif_data
+
+
+@pytest.fixture
+def image_with_exif_data(tmp_path):
+    """Fixture for an image with only the required EXIF data."""
+    image_file = tmp_path / 'test.png'
+    with Image.new(mode='1', size=(2, 2)) as im:
+        exif = im.getexif()
+
+        exif[ExifTags.Base.InterColorProfile] = 'some color profile'
+        exif[ExifTags.Base.Orientation] = 1
+
+        im.save(image_file, exif=exif)
+
+    return image_file
+
+
+@pytest.fixture
+def image_with_full_exif_data(image_with_exif_data):
+    """Fixture for an image with EXIF data."""
+    with Image.open(image_with_exif_data) as im:
+        exif = im.getexif()
+
+        exif[ExifTags.Base.CameraOwnerName] = 'Unknown'
+
+        exif[ExifTags.Base.Artist] = 'Stefanie Molin'
+        exif[ExifTags.Base.Copyright] = 'Copyright (c) Stefanie Molin.'
+
+        exif[ExifTags.IFD.GPSInfo] = {
+            ExifTags.GPS.GPSVersionID: 1,
+            ExifTags.GPS.GPSTrackRef: 1,
+        }
+
+        exif[ExifTags.Base.Make] = 'SomeCameraMake'
+        exif[ExifTags.Base.Model] = 'SomeCameraModel'
+        exif[ExifTags.Base.MakerNote] = 'Some maker notes'
+        exif[ExifTags.Base.MakerNoteSafety] = 1
+
+        exif[ExifTags.Base.LensMake] = 'SomeLensMake'
+        exif[ExifTags.Base.LensModel] = 'SomeLensModel'
+
+        exif[ExifTags.Base.BodySerialNumber] = 'ABC123'
+        exif[ExifTags.Base.CameraSerialNumber] = 'DEF456'
+        exif[ExifTags.Base.LensSerialNumber] = 'GHI789'
+
+        im.save(image_with_exif_data, exif=exif)
+
+    return image_with_exif_data

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,7 @@ from .common import has_expected_metadata
         (None, None),
         ([FieldGroup.ALL], True),
         ([FieldGroup.ALL, FieldGroup.GPS], False),
-        ([FieldGroup.GPS], None),
+        ([FieldGroup.GPS], True),
         ([FieldGroup.CAMERA, FieldGroup.LENS, FieldGroup.SERIALS], None),
     ],
 )
@@ -69,3 +69,10 @@ def test_main_access_cli(flag, return_code, image_with_full_exif_data):
         ]
     )
     assert result.returncode == return_code
+
+
+def test_cli_fields(capsys, image_with_full_exif_data):
+    """Confirm that copyright isn't allowed as a field to remove on its own via the CLI."""
+    with pytest.raises(SystemExit, match='2'):
+        cli.main(['--fields', 'copyright', str(image_with_full_exif_data)])
+    assert 'invalid choice' in capsys.readouterr().err.strip()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,9 +6,7 @@ import sys
 import pytest
 
 from exif_stripper import cli
-from exif_stripper.fields import (
-    FieldGroup,
-)
+from exif_stripper.fields import FieldGroup
 
 from .common import has_expected_metadata
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,123 +4,50 @@ import subprocess
 import sys
 
 import pytest
-from PIL import ExifTags, Image
 
 from exif_stripper import cli
-from exif_stripper.exceptions import UnknownFieldError
-from exif_stripper.fields import FIELDS, FieldGroup
+from exif_stripper.fields import (
+    FieldGroup,
+)
 
-
-@pytest.fixture
-def image_with_exif_data(tmp_path):
-    """Fixture for an image with EXIF data."""
-    image_file = tmp_path / 'test.png'
-    with Image.new(mode='1', size=(2, 2)) as im:
-        exif = im.getexif()
-
-        exif[ExifTags.IFD.GPSInfo] = {
-            ExifTags.GPS.GPSVersionID: 1,
-            ExifTags.GPS.GPSTrackRef: 1,
-        }
-
-        exif[ExifTags.Base.Make] = 'SomeCameraMake'
-        exif[ExifTags.Base.Model] = 'SomeCameraModel'
-        exif[ExifTags.Base.MakerNote] = 'Some maker notes'
-        exif[ExifTags.Base.MakerNoteSafety] = 1
-
-        exif[ExifTags.Base.LensMake] = 'SomeLensMake'
-        exif[ExifTags.Base.LensModel] = 'SomeLensModel'
-
-        exif[ExifTags.Base.BodySerialNumber] = 'ABC123'
-        exif[ExifTags.Base.CameraSerialNumber] = 'DEF456'
-        exif[ExifTags.Base.LensSerialNumber] = 'GHI789'
-
-        im.save(image_file, exif=exif)
-
-    return image_file
-
-
-def has_metadata(filepath, fields) -> bool:
-    """Utility to check if a file has metadata."""
-    with Image.open(filepath) as im:
-        exif = im.getexif()
-        if fields is None or FieldGroup.ALL in fields:
-            return bool(exif)
-        return all(tag in exif for field in fields for tag in FIELDS[field])
+from .common import has_expected_metadata
 
 
 @pytest.mark.parametrize(
-    'fields',
+    ('fields', 'preserve_copyright'),
     [
-        [FieldGroup.ALL],
-        [FieldGroup.ALL, FieldGroup.GPS],
-        [FieldGroup.GPS],
-        [FieldGroup.CAMERA, FieldGroup.LENS, FieldGroup.SERIALS],
+        (None, None),
+        ([FieldGroup.ALL], True),
+        ([FieldGroup.ALL, FieldGroup.GPS], False),
+        ([FieldGroup.GPS], None),
+        ([FieldGroup.CAMERA, FieldGroup.LENS, FieldGroup.SERIALS], None),
     ],
 )
-def test_process_image_full(monkeypatch, image_with_exif_data, fields):
-    """Test that cli.process_image() removes the appropriate EXIF metadata."""
-    assert has_metadata(image_with_exif_data, fields)
-
-    has_changed = cli.process_image(image_with_exif_data, fields=fields)
-
-    assert not has_metadata(image_with_exif_data, fields)
-    assert has_changed
-
-    has_changed = cli.process_image(image_with_exif_data, fields=fields)
-    assert not has_changed
-
-    # make sure that the other fields haven't been touched
-    if FieldGroup.ALL not in fields and (
-        expected_untouched_groups := set(FieldGroup).difference(
-            {FieldGroup.ALL, *fields}
-        )
-    ):
-        assert has_metadata(image_with_exif_data, expected_untouched_groups)
-
-
-def test_process_image_with_bad_field(image_with_exif_data):
-    """Test that cli.process_image() raises an exception when provided with invalid fields."""
-    with pytest.raises(UnknownFieldError):
-        cli.process_image(image_with_exif_data, fields=['garbage'])
-
-
-@pytest.mark.parametrize('exists', [True, False])
-def test_process_image_file_issues(tmp_path, exists):
-    """Test that cli.process_image() continues if files don't exist or aren't images."""
-    file = tmp_path / 'test.txt'
-    if exists:
-        file.touch()
-
-    has_changed = cli.process_image(file)
-    assert not has_changed
-
-
-@pytest.mark.parametrize(
-    'fields',
-    [
-        None,
-        [FieldGroup.ALL],
-        [FieldGroup.ALL, FieldGroup.GPS],
-        [FieldGroup.GPS],
-        [FieldGroup.CAMERA, FieldGroup.LENS, FieldGroup.SERIALS],
-    ],
-)
-def test_main(capsys, tmp_path, image_with_exif_data, fields):
+def test_main(
+    capsys,
+    image_without_exif_data,
+    image_with_full_exif_data,
+    fields,
+    preserve_copyright,
+):
     """Test that cli.main() returns the number of files altered."""
-    file_without_metadata = tmp_path / 'clean.png'
-    file_without_metadata.touch()
-
-    cli_args = [str(file_without_metadata), str(image_with_exif_data)]
+    cli_args = [str(image_without_exif_data), str(image_with_full_exif_data)]
     if fields is not None:
         cli_args = ['--fields', *[str(field) for field in fields], '--', *cli_args]
+    if preserve_copyright is False:
+        cli_args = ['--remove-copyright', *cli_args]
 
     files_changed = cli.main(cli_args)
 
     assert files_changed == 1
-    assert not has_metadata(image_with_exif_data, fields)
+    assert has_expected_metadata(
+        image_with_full_exif_data,
+        fields,
+        has_copyright=preserve_copyright is not False,
+        was_stripped=True,
+    )
 
-    assert capsys.readouterr().out.strip().endswith(str(image_with_exif_data))
+    assert capsys.readouterr().out.strip().endswith(str(image_with_full_exif_data))
 
 
 def test_cli_version(capsys):
@@ -131,9 +58,14 @@ def test_cli_version(capsys):
 
 
 @pytest.mark.parametrize(('flag', 'return_code'), [('--version', 0), ('', 1)])
-def test_main_access_cli(flag, return_code, image_with_exif_data):
+def test_main_access_cli(flag, return_code, image_with_full_exif_data):
     """Confirm that CLI can be accessed via python -m."""
     result = subprocess.run(
-        [sys.executable, '-m', 'exif_stripper.cli', flag or str(image_with_exif_data)]
+        [
+            sys.executable,
+            '-m',
+            'exif_stripper.cli',
+            flag or str(image_with_full_exif_data),
+        ]
     )
     assert result.returncode == return_code

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,0 +1,91 @@
+"""Test the image processing logic."""
+
+import pytest
+
+from exif_stripper.exceptions import UnknownFieldError
+from exif_stripper.fields import FieldGroup
+from exif_stripper.processing import process_image
+
+from .common import has_expected_metadata
+
+
+@pytest.mark.parametrize(
+    ('fields', 'preserve_copyright'),
+    [
+        ([FieldGroup.ALL], True),
+        ([FieldGroup.ALL, FieldGroup.GPS], False),
+        ([FieldGroup.GPS], None),
+        ([FieldGroup.CAMERA, FieldGroup.LENS, FieldGroup.SERIALS], None),
+    ],
+)
+def test_process_image_full(
+    capsys, monkeypatch, image_with_full_exif_data, fields, preserve_copyright
+):
+    """Test that process_image() removes the appropriate EXIF metadata."""
+    call_kwargs = {'fields': fields}
+    if preserve_copyright is not None:
+        call_kwargs['preserve_copyright'] = preserve_copyright
+
+    assert has_expected_metadata(
+        image_with_full_exif_data, fields, has_copyright=True, was_stripped=False
+    )
+
+    has_changed = process_image(image_with_full_exif_data, **call_kwargs)
+    should_have_copyright = preserve_copyright is not False
+
+    assert has_expected_metadata(
+        image_with_full_exif_data,
+        fields,
+        has_copyright=should_have_copyright,
+        was_stripped=True,
+    )
+    assert has_changed
+
+    has_changed = process_image(image_with_full_exif_data, **call_kwargs)
+    assert not has_changed
+
+    # make sure that the other fields haven't been touched
+    if FieldGroup.ALL not in fields and (
+        expected_untouched_groups := set(FieldGroup).difference(
+            {FieldGroup.ALL, *fields}
+        )
+    ):
+        assert has_expected_metadata(
+            image_with_full_exif_data,
+            expected_untouched_groups,
+            has_copyright=should_have_copyright,
+            was_stripped=False,
+        )
+
+
+def test_process_image_with_bad_field(image_with_full_exif_data):
+    """Test that process_image() raises an exception when provided with invalid fields."""
+    with pytest.raises(UnknownFieldError):
+        process_image(image_with_full_exif_data, fields=['garbage'])
+
+
+@pytest.mark.parametrize('exists', [True, False])
+def test_process_image_file_issues(tmp_path, exists):
+    """Test that process_image() continues if files don't exist or aren't images."""
+    file = tmp_path / 'test.txt'
+    if exists:
+        file.touch()
+
+    has_changed = process_image(file)
+    assert not has_changed
+
+
+def test_process_image_does_not_always_rewrite(capsys, image_with_exif_data):
+    """Test that process_image() doesn't rewrite the file if the EXIF data doesn't change."""
+    has_changed = process_image(image_with_exif_data)
+    assert not has_changed
+    assert not capsys.readouterr().out.strip().endswith(str(image_with_exif_data))
+
+
+def test_process_image_does_nothing_when_there_is_no_exif_data(
+    capsys, mocker, image_without_exif_data
+):
+    """Test that process_image() does nothing when the file has no EXIF data."""
+    has_changed = process_image(image_without_exif_data)
+    assert not has_changed
+    assert not capsys.readouterr().out.strip().endswith(str(image_without_exif_data))

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -78,7 +78,7 @@ def test_process_image_does_not_always_rewrite(capsys, image_with_exif_data):
 
 
 def test_process_image_does_nothing_when_there_is_no_exif_data(
-    capsys, mocker, image_without_exif_data
+    capsys, image_without_exif_data
 ):
     """Test that process_image() does nothing when the file has no EXIF data."""
     has_changed = process_image(image_without_exif_data)

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -13,35 +13,30 @@ from .common import has_expected_metadata
     ('fields', 'preserve_copyright'),
     [
         ([FieldGroup.ALL], True),
-        ([FieldGroup.ALL, FieldGroup.GPS], False),
-        ([FieldGroup.GPS], None),
-        ([FieldGroup.CAMERA, FieldGroup.LENS, FieldGroup.SERIALS], None),
+        ([FieldGroup.ALL, FieldGroup.GPS, FieldGroup.COPYRIGHT], False),
+        ([FieldGroup.GPS, FieldGroup.COPYRIGHT], False),
+        ([FieldGroup.CAMERA, FieldGroup.LENS, FieldGroup.SERIALS], True),
     ],
 )
 def test_process_image_full(
     capsys, monkeypatch, image_with_full_exif_data, fields, preserve_copyright
 ):
     """Test that process_image() removes the appropriate EXIF metadata."""
-    call_kwargs = {'fields': fields}
-    if preserve_copyright is not None:
-        call_kwargs['preserve_copyright'] = preserve_copyright
-
     assert has_expected_metadata(
         image_with_full_exif_data, fields, has_copyright=True, was_stripped=False
     )
 
-    has_changed = process_image(image_with_full_exif_data, **call_kwargs)
-    should_have_copyright = preserve_copyright is not False
+    has_changed = process_image(image_with_full_exif_data, fields=fields)
 
     assert has_expected_metadata(
         image_with_full_exif_data,
         fields,
-        has_copyright=should_have_copyright,
+        has_copyright=preserve_copyright,
         was_stripped=True,
     )
     assert has_changed
 
-    has_changed = process_image(image_with_full_exif_data, **call_kwargs)
+    has_changed = process_image(image_with_full_exif_data, fields=fields)
     assert not has_changed
 
     # make sure that the other fields haven't been touched
@@ -53,7 +48,7 @@ def test_process_image_full(
         assert has_expected_metadata(
             image_with_full_exif_data,
             expected_untouched_groups,
-            has_copyright=should_have_copyright,
+            has_copyright=preserve_copyright,
             was_stripped=False,
         )
 


### PR DESCRIPTION
- Restructure package
- Always keep ICC profile and orientation to avoid display issues
- Keep copyright and artist fields by default, but allow for opt-in deletion both when deleting everything and when deleting by group. Note that this is a change from before where everything was removed by default.

Closes #101